### PR TITLE
chore(deps): bump types/node-notifier to version 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
   "author": "Heroku",
   "bugs": "https://github.com/heroku/heroku-cli-notifications/issues",
   "dependencies": {
-    "node-notifier": "^8.0.1"
+    "node-notifier": "^8.0.1",
+    "@types/node-notifier": "8.0.5"
   },
   "devDependencies": {
     "@oclif/tslint": "^3.1.0",
     "@types/chai": "^4.1.4",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.9.4",
-    "@types/node-notifier": "^0.0.28",
     "chai": "^4.1.2",
     "mocha": "^5.2.0",
     "ts-node": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,9 +34,10 @@
   version "5.2.5"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.5.tgz#8a4accfc403c124a0bafe8a9fc61a05ec1032073"
 
-"@types/node-notifier@^0.0.28":
-  version "0.0.28"
-  resolved "https://registry.yarnpkg.com/@types/node-notifier/-/node-notifier-0.0.28.tgz#86ba3d3aa8d918352cc3191d88de328b20dc93c1"
+"@types/node-notifier@8.0.5":
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/@types/node-notifier/-/node-notifier-8.0.5.tgz#c5786810d16bbff10550e2d10efe5a17eaf1095e"
+  integrity sha512-LX7+8MtTsv6szumAp6WOy87nqMEdGhhry/Qfprjm1Ma6REjVzeF7SCyvPtp5RaF6IkXCS9V4ra8g5fwvf2ZAYg==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
Updates to much more recent version of node-notifier types that the main CLI can use.