### PR TITLE
fix: ignore workflows-repo in eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,7 @@ export default [
       './assets',
       './lib',
       '**/*.js',
+      'workflows-repo/**',
     ],
   },
   {


### PR DESCRIPTION
## Summary
- The Release workflow checks out `heroku/npm-release-workflows` into `./workflows-repo` before running `npm run lint`. Because `eslint .` walks the whole tree, it lints the workflow repo's own source and fails with 158 errors (single-quote rules, node: protocol, etc.).
- Add `workflows-repo/**` to `eslint.config.mjs` ignores so lint scopes to this package's files only.

## Test plan
- [x] Locally created a `workflows-repo/` directory with a deliberately bad `.mjs` file and ran `npm run lint`; output now reports only the 4 pre-existing warnings in `src/index.ts` (0 errors).
- [ ] Re-run the Release workflow to confirm the validate step passes.