### PR TITLE
fix: skip bundled notifier on Apple Silicon macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ See the [node-notifier](https://github.com/mikaelbr/node-notifier) docs for more
 
 ## Note
 
-On macOS Apple Silicon (M1/M2/M3/M4), desktop notifications may not appear without Rosetta 2.
+On macOS Apple Silicon (M1/M2/M3/M4), desktop notifications are skipped by default because the bundled `node-notifier` macOS binary is Intel-only.

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,13 @@ export interface Notification extends NodeNotification {
   force?: boolean
 }
 
+function shouldSkipBundledMacNotifier() {
+  return process.platform === 'darwin' && process.arch === 'arm64'
+}
+
 export function notify(notification: Notification = {}, callback?: NotificationCallback) {
   if (!notification.force && ['0', 'false'].includes(process.env.HEROKU_NOTIFICATIONS!)) return
+  if (shouldSkipBundledMacNotifier()) return
   try {
     return nodeNotify({
       appName: 'Microsoft.Windows.ShellExperienceHost_cw5n1h2txyewy!App',

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,9 +1,94 @@
-import {describe, it} from 'vitest'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+const {nodeNotify} = vi.hoisted(() => ({
+  nodeNotify: vi.fn(),
+}))
+
+vi.mock('node-notifier', () => ({
+  notify: nodeNotify,
+}))
 
 import {notify} from '../src'
 
+const originalArch = Object.getOwnPropertyDescriptor(process, 'arch')!
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+
+function setProcessTarget(platform: NodeJS.Platform, arch: string) {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: platform,
+  })
+  Object.defineProperty(process, 'arch', {
+    configurable: true,
+    value: arch,
+  })
+}
+
 describe('notify', () => {
+  beforeEach(() => {
+    setProcessTarget('linux', 'x64')
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'arch', originalArch)
+    Object.defineProperty(process, 'platform', originalPlatform)
+    vi.unstubAllEnvs()
+    nodeNotify.mockReset()
+  })
+
   it('notifies', () => {
     notify({message: 'body', title: 'test notification'})
+
+    expect(nodeNotify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        icon: expect.stringContaining('assets/heroku.png'),
+        message: 'body',
+        title: 'test notification',
+      }),
+      undefined,
+    )
+  })
+
+  it('does not notify when notifications are disabled', () => {
+    vi.stubEnv('HEROKU_NOTIFICATIONS', 'false')
+
+    notify({message: 'body', title: 'test notification'})
+
+    expect(nodeNotify).not.toHaveBeenCalled()
+  })
+
+  it('notifies when notifications are forced even if the environment disables them', () => {
+    vi.stubEnv('HEROKU_NOTIFICATIONS', 'false')
+
+    notify({force: true, message: 'body', title: 'test notification'})
+
+    expect(nodeNotify).toHaveBeenCalledOnce()
+  })
+
+  it('does not invoke the bundled notifier on Apple Silicon macOS', () => {
+    setProcessTarget('darwin', 'arm64')
+
+    notify({message: 'body', title: 'test notification'})
+
+    expect(nodeNotify).not.toHaveBeenCalled()
+  })
+
+  it('does not invoke the bundled notifier on Apple Silicon macOS when forced', () => {
+    setProcessTarget('darwin', 'arm64')
+
+    notify({
+      force: true,
+      message: 'body',
+      title: 'test notification',
+    })
+
+    expect(nodeNotify).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- Skip invoking `node-notifier` on macOS Apple Silicon, where its bundled `terminal-notifier.app` is Intel-only.
- Preserve the existing `HEROKU_NOTIFICATIONS=0|false` behavior and `force` behavior on other platforms.
- Expand unit coverage so the wrapper does not call `node-notifier` on `darwin` + `arm64`.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [x] **test**: Add/update/remove tests

## Testing
**Notes**:
Validated locally on macOS Apple Silicon. `npm test` passes; lint exits successfully with existing warnings in `src/index.ts`.

**Steps**:
1. `npm run build`
2. `npm test`

## Screenshots (if applicable)
N/A

## Related Issues
GitHub issue: https://github.com/heroku/cli/issues/3784
Also related to https://github.com/heroku/cli/issues/2471 and https://github.com/mikaelbr/node-notifier/issues/361.