### PR TITLE
fix: replace node-notifier with native per-OS notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,6 @@
       "name": "@heroku-cli/notifications",
       "version": "1.2.7",
       "license": "MIT",
-      "dependencies": {
-        "@types/node-notifier": "8.0.5",
-        "node-notifier": "^10.0.1"
-      },
       "devDependencies": {
         "@types/node": "24.10.1",
         "@vitest/coverage-v8": "^4.1.8",
@@ -962,18 +958,10 @@
       "version": "24.10.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
-      }
-    },
-    "node_modules/@types/node-notifier": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/@types/node-notifier/-/node-notifier-8.0.5.tgz",
-      "integrity": "sha512-LX7+8MtTsv6szumAp6WOy87nqMEdGhhry/Qfprjm1Ma6REjVzeF7SCyvPtp5RaF6IkXCS9V4ra8g5fwvf2ZAYg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -3795,12 +3783,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/growly": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
-      "license": "MIT"
-    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -4139,21 +4121,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4401,18 +4368,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -4424,6 +4379,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -5055,20 +5011,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/node-notifier": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-10.0.1.tgz",
-      "integrity": "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==",
-      "license": "MIT",
-      "dependencies": {
-        "growly": "^1.3.0",
-        "is-wsl": "^2.2.0",
-        "semver": "^7.3.5",
-        "shellwords": "^0.1.1",
-        "uuid": "^8.3.2",
-        "which": "^2.0.2"
       }
     },
     "node_modules/node-releases": {
@@ -5836,6 +5778,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
       "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5915,12 +5858,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/shellwords": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "license": "MIT"
     },
     "node_modules/side-channel": {
       "version": "1.1.1",
@@ -6495,6 +6432,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -6574,19 +6512,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {
@@ -6783,6 +6708,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -4,10 +4,6 @@
   "version": "1.2.7",
   "author": "Heroku",
   "bugs": "https://github.com/heroku/heroku-cli-notifications/issues",
-  "dependencies": {
-    "@types/node-notifier": "8.0.5",
-    "node-notifier": "^10.0.1"
-  },
   "devDependencies": {
     "@types/node": "24.10.1",
     "@vitest/coverage-v8": "^4.1.8",
@@ -38,8 +34,5 @@
     "prepublishOnly": "npm run build",
     "test": "vitest run --coverage"
   },
-  "types": "lib/index.d.ts",
-  "overrides": {
-    "uuid": "^11.1.1"
-  }
+  "types": "lib/index.d.ts"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,105 @@
+import {execFile} from 'node:child_process'
 import * as path from 'node:path'
-import {Notification as NodeNotification, NotificationCallback, notify as nodeNotify} from 'node-notifier'
-export interface Notification extends NodeNotification {
+
+export type NotificationCallback = (error: Error | null, response: string) => void
+
+export interface Notification {
+  /** deliver even when HEROKU_NOTIFICATIONS is disabled */
   force?: boolean
+  /** absolute path to an icon (Linux only) */
+  icon?: string
+  /** body text of the notification */
+  message?: string
+  /** play a sound with the notification */
+  sound?: boolean | string
+  /** secondary text shown below the title (macOS only) */
+  subtitle?: string
+  /** main title; defaults to "Heroku CLI" */
+  title?: string
 }
 
+const DEFAULT_TITLE = 'Heroku CLI'
+const DEFAULT_ICON = path.join(__dirname, '../assets/heroku.png')
+
+/**
+ * Escapes a value for use inside an AppleScript double-quoted string literal.
+ * Backslashes must be escaped before quotes so the added escapes are not re-escaped.
+ */
+function escapeAppleScript(value: string): string {
+  return value.replaceAll('\\', '\\\\').replaceAll('"', String.raw`\"`)
+}
+
+/**
+ * Escapes a value for use inside a PowerShell single-quoted string literal,
+ * where the only special character is the single quote itself (doubled).
+ */
+function escapePowerShell(value: string): string {
+  return value.replaceAll("'", "''")
+}
+
+function notifyDarwin(n: Notification): [string, string[]] {
+  const title = escapeAppleScript(n.title ?? DEFAULT_TITLE)
+  let script = `display notification "${escapeAppleScript(n.message ?? '')}" with title "${title}"`
+  if (n.subtitle) script += ` subtitle "${escapeAppleScript(n.subtitle)}"`
+  if (n.sound) script += ' sound name "default"'
+  return ['osascript', ['-e', script]]
+}
+
+function notifyLinux(n: Notification): [string, string[]] {
+  const summary = n.title ?? DEFAULT_TITLE
+  const body = [n.subtitle, n.message].filter(Boolean).join('\n')
+  const args: string[] = []
+  const icon = n.icon ?? DEFAULT_ICON
+  if (icon) args.push('--icon', icon)
+  args.push(summary, body)
+  return ['notify-send', args]
+}
+
+function notifyWindows(n: Notification): [string, string[]] {
+  const title = escapePowerShell(n.title ?? DEFAULT_TITLE)
+  const message = escapePowerShell(n.message ?? '')
+  // Build a WinRT toast from the bundled ToastText02 template via PowerShell.
+  const script = [
+    '[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null;',
+    '[Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom.XmlDocument, ContentType = WindowsRuntime] | Out-Null;',
+    '$template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02);',
+    '$texts = $template.GetElementsByTagName("text");',
+    `$texts.Item(0).AppendChild($template.CreateTextNode('${title}')) | Out-Null;`,
+    `$texts.Item(1).AppendChild($template.CreateTextNode('${message}')) | Out-Null;`,
+    '$toast = [Windows.UI.Notifications.ToastNotification]::new($template);',
+    `[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('${title}').Show($toast);`,
+  ].join(' ')
+  return ['powershell', ['-NoProfile', '-NonInteractive', '-Command', script]]
+}
+
+const dispatchers: Partial<Record<NodeJS.Platform, (n: Notification) => [string, string[]]>> = {
+  darwin: notifyDarwin,
+  linux: notifyLinux,
+  win32: notifyWindows,
+}
+
+/**
+ * Display a desktop notification using the host OS's native tooling
+ * (osascript on macOS, notify-send on Linux, PowerShell toast on Windows).
+ *
+ * Best-effort and fire-and-forget: any failure (missing tool, unsupported
+ * platform) is swallowed so callers never see a notification break a command.
+ */
 export function notify(notification: Notification = {}, callback?: NotificationCallback) {
   if (!notification.force && ['0', 'false'].includes(process.env.HEROKU_NOTIFICATIONS!)) return
+
+  const dispatcher = dispatchers[process.platform]
+  if (!dispatcher) {
+    callback?.(null, '')
+    return
+  }
+
   try {
-    return nodeNotify({
-      appName: 'Microsoft.Windows.ShellExperienceHost_cw5n1h2txyewy!App',
-      icon: path.join(__dirname, '../assets/heroku.png'),
-      title: 'Heroku CLI',
-      ...notification,
-    } as Notification, callback)
-  } catch {}
+    const [command, args] = dispatcher(notification)
+    execFile(command, args, error => {
+      callback?.(error, '')
+    })
+  } catch {
+    callback?.(null, '')
+  }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,9 +1,151 @@
-import {describe, it} from 'vitest'
+import {execFile} from 'node:child_process'
+import {
+  afterEach, beforeEach, describe, expect, it, vi,
+} from 'vitest'
 
 import {notify} from '../src'
 
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn((_cmd: string, _args: string[], cb?: (err: Error | null, stdout: string, stderr: string) => void) => {
+    if (typeof cb === 'function') cb(null, '', '')
+    return {}
+  }),
+}))
+
+const execFileMock = vi.mocked(execFile)
+
+const originalPlatform = process.platform
+
+function setPlatform(platform: NodeJS.Platform) {
+  Object.defineProperty(process, 'platform', {configurable: true, value: platform})
+}
+
+/** Returns the [command, args] of the single execFile call. */
+function lastCall(): [string, string[]] {
+  expect(execFileMock).toHaveBeenCalledTimes(1)
+  const [cmd, args] = execFileMock.mock.calls[0]
+  return [cmd as string, args as string[]]
+}
+
 describe('notify', () => {
-  it('notifies', () => {
-    notify({message: 'body', title: 'test notification'})
+  beforeEach(() => {
+    execFileMock.mockClear()
+    delete process.env.HEROKU_NOTIFICATIONS
+  })
+
+  afterEach(() => {
+    setPlatform(originalPlatform)
+  })
+
+  describe('macOS', () => {
+    beforeEach(() => setPlatform('darwin'))
+
+    it('invokes osascript with a display notification script', () => {
+      notify({message: 'dyno is up', subtitle: 'heroku run bash', title: 'my-app'})
+      const [cmd, args] = lastCall()
+      expect(cmd).toBe('osascript')
+      expect(args[0]).toBe('-e')
+      const script = args[1]
+      expect(script).toContain('display notification "dyno is up"')
+      expect(script).toContain('with title "my-app"')
+      expect(script).toContain('subtitle "heroku run bash"')
+    })
+
+    it('adds a sound clause when sound is truthy', () => {
+      notify({message: 'done', sound: true})
+      const [, args] = lastCall()
+      expect(args[1]).toContain('sound name "default"')
+    })
+
+    it('omits the sound clause when sound is absent', () => {
+      notify({message: 'done'})
+      const [, args] = lastCall()
+      expect(args[1]).not.toContain('sound name')
+    })
+
+    it('escapes double quotes and backslashes in fields', () => {
+      notify({message: 'say "hi"', title: String.raw`a\b`})
+      const [, args] = lastCall()
+      expect(args[1]).toContain(String.raw`display notification "say \"hi\""`)
+      expect(args[1]).toContain(String.raw`with title "a\\b"`)
+    })
+
+    it('defaults the title to "Heroku CLI"', () => {
+      notify({message: 'done'})
+      const [, args] = lastCall()
+      expect(args[1]).toContain('with title "Heroku CLI"')
+    })
+  })
+
+  describe('Linux', () => {
+    beforeEach(() => setPlatform('linux'))
+
+    it('invokes notify-send with summary and body', () => {
+      notify({message: 'dyno is up', subtitle: 'heroku run bash', title: 'my-app'})
+      const [cmd, args] = lastCall()
+      expect(cmd).toBe('notify-send')
+      expect(args).toContain('my-app')
+      // subtitle and message are joined into the body
+      expect(args.some(a => a.includes('heroku run bash') && a.includes('dyno is up'))).toBe(true)
+    })
+
+    it('passes an --icon flag when icon is provided', () => {
+      notify({icon: '/tmp/heroku.png', message: 'done'})
+      const [, args] = lastCall()
+      const iconIndex = args.indexOf('--icon')
+      expect(iconIndex).toBeGreaterThanOrEqual(0)
+      expect(args[iconIndex + 1]).toBe('/tmp/heroku.png')
+    })
+  })
+
+  describe('Windows', () => {
+    beforeEach(() => setPlatform('win32'))
+
+    it('invokes powershell with a script containing the message and title', () => {
+      notify({message: 'dyno is up', title: 'my-app'})
+      const [cmd, args] = lastCall()
+      expect(cmd.toLowerCase()).toContain('powershell')
+      const script = args.join(' ')
+      expect(script).toContain('dyno is up')
+      expect(script).toContain('my-app')
+    })
+  })
+
+  describe('gating', () => {
+    beforeEach(() => setPlatform('darwin'))
+
+    it('does nothing when HEROKU_NOTIFICATIONS=0', () => {
+      process.env.HEROKU_NOTIFICATIONS = '0'
+      notify({message: 'done'})
+      expect(execFileMock).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when HEROKU_NOTIFICATIONS=false', () => {
+      process.env.HEROKU_NOTIFICATIONS = 'false'
+      notify({message: 'done'})
+      expect(execFileMock).not.toHaveBeenCalled()
+    })
+
+    it('still notifies when force is set despite HEROKU_NOTIFICATIONS=0', () => {
+      process.env.HEROKU_NOTIFICATIONS = '0'
+      notify({force: true, message: 'done'})
+      expect(execFileMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('does nothing on an unsupported platform', () => {
+      setPlatform('freebsd' as NodeJS.Platform)
+      notify({message: 'done'})
+      expect(execFileMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('callback', () => {
+    beforeEach(() => setPlatform('darwin'))
+
+    it('invokes the callback when provided', () => {
+      const cb = vi.fn()
+      notify({message: 'done'}, cb)
+      expect(cb).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,9 @@
     "declaration": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
+    "lib": [
+      "es2021"
+    ],
     "module": "commonjs",
     "outDir": "./lib",
     "pretty": true,


### PR DESCRIPTION
## Summary

Replace the abandoned `node-notifier` dependency with native, per-OS notification commands so the package ships no vendored binaries. This removes the Intel-only `terminal-notifier.app` that triggers macOS's "Support Ending for Intel-based Apps" warning on Apple Silicon, while keeping the public `notify()` API and its semantics unchanged.

- Replace `node-notifier` dispatch with `osascript` (macOS), `notify-send` (Linux), and a PowerShell WinRT toast (Windows), invoked via `execFile`.
- Remove the `node-notifier` and `@types/node-notifier` dependencies and the now-stale `uuid` override.
- Add per-shell escaping (AppleScript double-quote/backslash, PowerShell single-quote) for all user-supplied fields.
- Add a 13-case vitest suite covering each platform, `HEROKU_NOTIFICATIONS` gating, the `force` override, unsupported platforms, and callback wiring.
- Update `tsconfig.json` to `lib: es2021` for `String.prototype.replaceAll`.
- Preserve best-effort/fire-and-forget behavior: failures and unsupported platforms silently no-op.

## Type of Change

- [x] **fix**: Bug fix or issue (patch semvar update)
- [ ] **feat**: Introduces a new feature to the codebase (minor semvar update)
- [ ] **perf**: Performance improvement
- [ ] **docs**: Documentation only changes
- [ ] **tests**: Adding missing tests or correcting existing tests
- [ ] **chore**: Code cleanup tasks, dependency updates, or other changes


## Verification

```bash
npm install
npm test       # 13 passing
npm run build  # produces lib/index.js (gitignored, no prepare script — must build before linking)
```

`@heroku-cli/notifications` is a dependency the CLI imports, not an oclif plugin, so
swap it with a one-line `package.json` edit (no `heroku plugins:link`). From your
local `heroku/cli` checkout, with this branch built and linked via its absolute path:

```diff
- "@heroku-cli/notifications": "^1.2.6",
+ "@heroku-cli/notifications": "file:/absolute/path/to/heroku-cli-notifications",
```

```bash
npm install && npm run build   # rebuild dist/ so it resolves the swapped dep
```

Confirm the Intel binary that triggers the macOS warning is gone:

```bash
# before: file node_modules/node-notifier/.../terminal-notifier → Mach-O x86_64
find node_modules/@heroku-cli/notifications -name terminal-notifier   # → (no output)
ls node_modules/node-notifier 2>/dev/null || echo "node-notifier: gone"
```

Then exercise the real notification path. Use `example-http-proxy` (a Private Space
app) — `heroku run` only notifies when a dyno takes >20s to start, which it reliably
does there:

```bash
./bin/run.js run "echo hi" -a example-http-proxy
```

Expect the "dyno is up" desktop banner via native `osascript`, with no
"Support Ending for Intel-based Apps" warning. No app is created or destroyed.

Revert when done:

```bash
git checkout package.json package-lock.json && npm install
```

## Additional Context

- **Behavior change:** `osascript` cannot render a custom `contentImage`, so the success/error icon flourish is dropped on macOS (title/subtitle/message/sound remain). Linux still honors `icon`.
- **Why now:** `node-notifier` was last published Feb 2022; its Apple Silicon issue (mikaelbr/node-notifier#361) is unfixed upstream and the bundled `terminal-notifier` is x86_64-only and unsigned. Going native also drops `snoreToast` (~4.4MB) and `notifu`.
- **Follow-up:** after publishing (suggest `1.3.0`), bump `@heroku-cli/notifications` in `heroku/cli`; its `src/lib/notify.ts` still passes `contentImage`, which is now harmlessly ignored on macOS and can be cleaned up.

## Related Issue

Closes heroku/cli#3784





